### PR TITLE
Small change to always display two decimals

### DIFF
--- a/views/space.erb
+++ b/views/space.erb
@@ -25,7 +25,7 @@
                     <div class='card-body'>
                         <h5 class='card-title'><%= space.title %></h5>
                         <p class='card-text'><%= space.description %></p>
-                        <p class='card-text'><strong>£<%= space.price %> per night</strong> </p>
+                        <p class='card-text'><strong>£<%= '%.2f' % space.price %> per night</strong> </p>
                     
                     <% if space.available == true %>
                         <form action="/book" method='post'>
@@ -36,11 +36,9 @@
                         <p>Unavailable</p>
                     <% end %>
                     </div>
-
                 </div>
             <% end %>
         </div>
-
     </div>
 
 </body>


### PR DESCRIPTION
Using `sprintf` to always display two decimal places, even when the price is a round number like £50.00.
Closes #37 